### PR TITLE
Fix OpenQASM 2.0 syntax for measurement

### DIFF
--- a/QasmPrinting.hs
+++ b/QasmPrinting.hs
@@ -375,7 +375,7 @@ qasm_render_gate wtm (QMeas w) = do
   (ns,wr) <- SM.get
   let wr' = Map.delete w wr
   let wr'' = Map.insert w ("canc"++ show w,0,Cbit) wr'  
-  return $ "creg canc" ++ show w ++ "[1];\nmeasure -> canc" ++ show w ++ "[0];\n"
+  return $ "creg canc" ++ show w ++ "[1];\nmeasure anc" ++ show w ++ "[0] -> canc" ++ show w ++ "[0];\n"
 
 -- QASM do not support Discard a qubit, we just ignore this 
 qasm_render_gate wtm (QDiscard w) = return ""


### PR DESCRIPTION
Currently, QasmPrinting produces QASM that looks like this:

    measure -> canc[0]

But this does not appear to be valid OpenQASM 2.0 syntax, so output the following instead:

    measure anc[0] -> canc[0]

(Am I right about this?)