### PR TITLE
Add rudimentary support for OpenQASM 3.0

### DIFF
--- a/QasmTransformer.hs
+++ b/QasmTransformer.hs
@@ -208,3 +208,6 @@ normalctrls_transformer gate@(T_Comment _ _ _) = identity_transformer gate
 qasm_generic cir = cir' where
   cir' = transform_generic normalctrls_transformer c2
   c2 = transform_generic trimctrls_tof_transformer cir
+
+qasm3_generic cir = cir' where
+  cir' = transform_generic normalctrls_transformer cir


### PR DESCRIPTION
I'm not much of a Haskell or Quipper expert, but here is some effort towards OpenQASM 3 support.

Specifically, this introduces the `ctrl@` gate modifier so that this tool does not need to decompose, for example, multi-controlled P(theta) gates on its own. You can pass the flag `-3` on the command line to turn that on